### PR TITLE
Modify `Identifiable::id` to return type `&ARID`

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -54,8 +54,8 @@ impl Account {
         }
     }
 
-    pub fn id(&self) -> ARID {
-        self.id
+    pub fn id(&self) -> &ARID {
+        &self.id
     }
 
     pub fn name(&self) -> &str {

--- a/src/identifiable.rs
+++ b/src/identifiable.rs
@@ -5,5 +5,5 @@ use bc_components::ARID;
 /// A trait for objects that have a unique identifier within the wallet
 /// interchange format.
 pub trait Identifiable {
-    fn id(&self) -> ARID;
+    fn id(&self) -> &ARID;
 }

--- a/src/zewif_top.rs
+++ b/src/zewif_top.rs
@@ -31,7 +31,7 @@ impl ZewifTop {
     }
 
     pub fn add_wallet(&mut self, wallet: ZewifWallet) {
-        self.wallets.insert(wallet.id(), wallet);
+        self.wallets.insert(wallet.id().clone(), wallet);
     }
 
     pub fn transactions(&self) -> &HashMap<TxId, Transaction> {

--- a/src/zewif_wallet.rs
+++ b/src/zewif_wallet.rs
@@ -35,8 +35,8 @@ impl std::fmt::Debug for ZewifWallet {
 }
 
 impl Identifiable for ZewifWallet {
-    fn id(&self) -> ARID {
-        self.id
+    fn id(&self) -> &ARID {
+        &self.id
     }
 }
 
@@ -53,8 +53,8 @@ impl ZewifWallet {
         }
     }
 
-    pub fn id(&self) -> ARID {
-        self.id
+    pub fn id(&self) -> &ARID {
+        &self.id
     }
 
     pub fn network(&self) -> Network {
@@ -74,6 +74,6 @@ impl ZewifWallet {
     }
 
     pub fn add_account(&mut self, account: Account) {
-        self.accounts.insert(account.id(), account);
+        self.accounts.insert(account.id().clone(), account);
     }
 }


### PR DESCRIPTION
ARID is not a `Copy` type, and consequently should be returned by reference, allowing the caller to clone the value when required.